### PR TITLE
Development builds should apply release optimisations

### DIFF
--- a/Source/CMakeTarget.Build.cs
+++ b/Source/CMakeTarget.Build.cs
@@ -240,7 +240,6 @@ public class CMakeTargetInst
         switch(target.Configuration)
         {
             case UnrealTargetConfiguration.Debug:
-            case UnrealTargetConfiguration.Development:
             case UnrealTargetConfiguration.DebugGame:
                 buildType="Debug";
                 break;


### PR DESCRIPTION
According to the documentation (https://docs.unrealengine.com/5.1/en-US/build-configurations-reference-for-unreal-engine/) it looks like only `Debug` and `DebugGame` need to be compiled without optimisation. This PR seems more technically correct to me.