### PR TITLE
Ensure the libs are not compiled in Debug mode with DebugGame as target.

### DIFF
--- a/Source/CMakeTarget.Build.cs
+++ b/Source/CMakeTarget.Build.cs
@@ -240,7 +240,6 @@ public class CMakeTargetInst
         switch(target.Configuration)
         {
             case UnrealTargetConfiguration.Debug:
-            case UnrealTargetConfiguration.DebugGame:
                 buildType="Debug";
                 break;
             default:


### PR DESCRIPTION
Fixes #19

As specified [here](https://github.com/caseymcc/UE4CMake/issues/19#issuecomment-2080824623) the DebugGame is like Development minus optimization. So, it's necessary not to build the libraries in Debug.