### PR TITLE
Improves the configuration process.

### DIFF
--- a/Source/CMakeLists.in
+++ b/Source/CMakeLists.in
@@ -85,6 +85,11 @@ macro(target_build_info build_info target)
 
     list(APPEND target_file_source_dependencies $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:${target},SOURCES>>)
 
+    # Extract compile definitions
+    list(APPEND target_defines $<TARGET_PROPERTY:${target},INTERFACE_COMPILE_DEFINITIONS>)
+    list(APPEND target_defines $<TARGET_PROPERTY:${target},PUBLIC_COMPILE_DEFINITIONS>)
+    list(REMOVE_DUPLICATES target_defines)
+
     # Store dependent targets
     ue4_get_target_link_libraries(target_binary_libs target_link_lib_files target_binary_dirs target_dependencies ${target})
 
@@ -102,6 +107,7 @@ macro(target_build_info build_info target)
     string(REPLACE ";" "$<SEMICOLON>" target_binary_libs "${target_binary_libs}")
     string(REPLACE ";" "$<SEMICOLON>" target_binary_dirs "${target_binary_dirs}")
     string(REPLACE ";" "$<SEMICOLON>" target_link_lib_files "${target_link_lib_files}")
+    string(REPLACE ";" "$<SEMICOLON>" target_defines "${target_defines}")
 
     list(APPEND ${build_info} "cppStandard=$<TARGET_PROPERTY:${target},CXX_STANDARD>")
     list(APPEND ${build_info} "includes=$<JOIN:$<REMOVE_DUPLICATES:${target_includes}>,$<COMMA>>")
@@ -111,6 +117,7 @@ macro(target_build_info build_info target)
     list(APPEND ${build_info} "binaries=$<JOIN:$<REMOVE_DUPLICATES:${target_binary_libs}>,$<COMMA>>")
     list(APPEND ${build_info} "binaryDirectories=$<JOIN:${target_binary_dirs},$<COMMA>>")
     list(APPEND ${build_info} "libraries=$<JOIN:$<REMOVE_DUPLICATES:${target_link_lib_files}>,$<COMMA>>")
+    list(APPEND ${build_info} "defines=$<JOIN:$<REMOVE_DUPLICATES:${target_defines}>,$<COMMA>>")
 endmacro()
 
 cmake_policy(SET CMP0091 NEW)

--- a/Source/CMakeLists.in
+++ b/Source/CMakeLists.in
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-#using undocumented cmake functionality to force global on imported targets
+# Using undocumented cmake functionality to force global on imported targets
 function(add_library)
     set(_args ${ARGN})
     if ("${_args}" MATCHES ";IMPORTED")
@@ -9,11 +9,14 @@ function(add_library)
     _add_library(${_args})
 endfunction()
 
-function(_ue4_get_target_link_libraries addTarget target_file_list target_linker_file_list target_directories)
+function(_ue4_get_target_link_libraries addTarget target_file_list target_linker_file_list target_directories target_dependencies_list)
     foreach(target ${ARGN})
         if(TARGET ${target})
-            get_target_property(target_libraries ${target} INTERFACE_LINK_LIBRARIES)
-            get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
+            # Add this target to our dependencies list
+            list(APPEND ${target_dependencies_list} ${target})
+
+            get_target_property(interface_libs ${target} INTERFACE_LINK_LIBRARIES)
+            get_target_property(link_libs ${target} LINK_LIBRARIES)
             get_target_property(target_type ${target} TYPE)
 
             if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (@FORCE_RELEASE_RUNTIME@))
@@ -26,9 +29,13 @@ function(_ue4_get_target_link_libraries addTarget target_file_list target_linker
                 endif()
             endif()
 
-            if(target_libraries)
-                #get info for targets libs
-                _ue4_get_target_link_libraries(TRUE ${target_file_list} ${target_linker_file_list} ${target_directories} ${target_libraries})
+            # Recursively process interface_libs
+            if(interface_libs)
+                _ue4_get_target_link_libraries(TRUE ${target_file_list} ${target_linker_file_list} ${target_directories} ${target_dependencies_list} ${interface_libs})
+            endif()
+            # Recursively process link_libs
+            if(link_libs)
+                _ue4_get_target_link_libraries(TRUE ${target_file_list} ${target_linker_file_list} ${target_directories} ${target_dependencies_list} ${link_libs})
             endif()
 
             if(${addTarget})
@@ -39,11 +46,10 @@ function(_ue4_get_target_link_libraries addTarget target_file_list target_linker
                 if(target_type STREQUAL "STATIC_LIBRARY"
                     OR target_type STREQUAL "SHARED_LIBRARY")
                     list(APPEND ${target_linker_file_list} "$<TARGET_LINKER_FILE:${target}>")
-                endif ()
+                endif()
             endif()
         else()
-            #not a target, need to hunt for library to include
-            #currently ignored, use targets instead of files
+            # Not a target, currently ignored
         endif()
     endforeach()
 
@@ -59,12 +65,14 @@ function(_ue4_get_target_link_libraries addTarget target_file_list target_linker
         list(REMOVE_DUPLICATES ${target_linker_file_list})
         set(${target_linker_file_list} ${${target_linker_file_list}} PARENT_SCOPE)
     endif()
-
-
+    if(${target_dependencies_list})
+        list(REMOVE_DUPLICATES ${target_dependencies_list})
+        set(${target_dependencies_list} ${${target_dependencies_list}} PARENT_SCOPE)
+    endif()
 endfunction()
 
-macro(ue4_get_target_link_libraries target_file_list target_linker_file_list target_directories)
-    _ue4_get_target_link_libraries(TRUE ${target_file_list} ${target_linker_file_list} ${target_directories} ${ARGN})
+macro(ue4_get_target_link_libraries target_file_list target_linker_file_list target_directories target_dependencies_list)
+    _ue4_get_target_link_libraries(TRUE ${target_file_list} ${target_linker_file_list} ${target_directories} ${target_dependencies_list} ${ARGN})
 endmacro()
 
 macro(target_build_info build_info target)
@@ -77,7 +85,16 @@ macro(target_build_info build_info target)
 
     list(APPEND target_file_source_dependencies $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:${target},SOURCES>>)
 
-    ue4_get_target_link_libraries(target_binary_libs target_link_lib_files target_binary_dirs ${target})
+    # Store dependent targets
+    ue4_get_target_link_libraries(target_binary_libs target_link_lib_files target_binary_dirs target_dependencies ${target})
+
+    # For each dependent target, get its sources and add them to source_dependencies
+    foreach(dep ${target_dependencies})
+        get_target_property(dep_sources ${dep} SOURCES)
+        if(dep_sources)
+            list(APPEND target_file_source_dependencies ${dep_sources})
+        endif()
+    endforeach()
 
     string(REPLACE ";" "$<SEMICOLON>" target_includes "${target_includes}")
     string(REPLACE ";" "$<SEMICOLON>" target_file_dependencies "${target_file_dependencies}")

--- a/Source/CMakeTarget.Build.cs
+++ b/Source/CMakeTarget.Build.cs
@@ -228,6 +228,19 @@ public class CMakeTargetInst
             }
         }
 
+        if(values.ContainsKey("defines"))
+        {
+            string[] defines = values["defines"].Split(',');
+
+            foreach(string define in defines)
+            {
+                if(String.IsNullOrEmpty(define))
+                    continue;
+
+                rules.PublicDefinitions.Add(define);
+            }
+        }
+
         return true;
     }
 

--- a/Source/CMakeTarget.Build.cs
+++ b/Source/CMakeTarget.Build.cs
@@ -123,14 +123,20 @@ public class CMakeTargetInst
         StreamReader reader = new System.IO.StreamReader(m_buildInfoPath);
         string line = null;
 
-        while((line=reader.ReadLine())!=null)
+        while ((line = reader.ReadLine()) != null)
         {
-            string[] tokens = line.Split('=');
+            int separatorIndex = line.IndexOf('=');
 
-            if(tokens.Length!=2)
+            // Skip lines that don't have an '='
+            if (separatorIndex == -1)
                 continue;
 
-            values.Add(tokens[0], tokens[1]);
+            // Extract the token (key) and value
+            string key = line.Substring(0, separatorIndex).Trim();
+            string value = line.Substring(separatorIndex + 1).Trim();
+
+            // Add to the dictionary
+            values.Add(key, value);
         }
 
         if(values.ContainsKey("cppStandard"))
@@ -198,6 +204,7 @@ public class CMakeTargetInst
                     continue;
 
                 rules.PublicIncludePaths.Add(include);
+                Console.WriteLine("PublicIncludePaths.Add("+include+")");
             }
         }
 
@@ -210,8 +217,8 @@ public class CMakeTargetInst
                 if(String.IsNullOrEmpty(binaryDirectory))
                     continue;
 
-                Console.WriteLine("Add library path: "+binaryDirectory);
                 rules.PublicRuntimeLibraryPaths.Add(binaryDirectory);
+                Console.WriteLine("PublicRuntimeLibraryPaths.Add("+binaryDirectory+")");
             }
         }
 
@@ -225,6 +232,7 @@ public class CMakeTargetInst
                     continue;
 
                 rules.PublicAdditionalLibraries.Add(library);
+                Console.WriteLine("PublicAdditionalLibraries.Add("+library+")");
             }
         }
 
@@ -238,9 +246,11 @@ public class CMakeTargetInst
                     continue;
 
                 rules.PublicDefinitions.Add(define);
+                Console.WriteLine("PublicDefinitions.Add("+define+")");
             }
         }
 
+        Console.WriteLine("Loading done.");
         return true;
     }
 


### PR DESCRIPTION
These commits improve the ability of this plugin to include any CMake library without requiring configuration on the Unreal Engine module side.

Specifically, these commits:

1. Capture the source files of sub-libraries and insert them as dependencies for Unreal, ensuring that if a file changes, Unreal knows the CMake module requires a rebuild.
2. Fetch all the PUBLIC preprocessor definitions (macros) specified by the CMake libraries and sub-libraries and include them automatically as PublicDefinitions, drastically reducing the chances of missing a define and breaking the ABI.